### PR TITLE
fix probabilities and ibc helper

### DIFF
--- a/src/helpers/ibc.js
+++ b/src/helpers/ibc.js
@@ -39,10 +39,10 @@ const fa = (Ss, tp) => {
 
 const ibc = async (location, soilType) => {
 	let prob = await probabilities(location, 0.2);
-	let Ss = interpolation(prob, 1.0 / 2500.0); //PGA1
+	let Ss = interpolation(prob, 1.0 / 2475.0); //PGA1
 
 	let prob2 = await probabilities(location, 1.0);
-	let Sl = interpolation(prob2, 1.0 / 2500.0); //PGA2
+	let Sl = interpolation(prob2, 1.0 / 2475.0); //PGA2
 
 	let Fv = fv(Sl, soilType);
 	let Fa = fa(Ss, soilType);

--- a/src/helpers/probabilities.js
+++ b/src/helpers/probabilities.js
@@ -18,6 +18,7 @@ const probabilities = async (location, period) => {
   let Y_mc = [];
   let Y_ab = [];
   let Y_bc = [];
+  let Y = [];
 
   try {
     const locationData = await Location.findByPk(location);
@@ -103,7 +104,7 @@ const probabilities = async (location, period) => {
         throw {status: 404, message: "There is no information in the DB with this location or period"};
     }
 
-    // if (!zer_data) throw {status: 404, message: "There is no information in the DB with this location or period"};
+    if (!zer_data) throw {status: 404, message: "There is no information in the DB with this location or period"};
 
     for (const data of zer_data) {
       X.push(data.X);
@@ -112,18 +113,19 @@ const probabilities = async (location, period) => {
       Y_mc.push(data.Y_mc);
       Y_ab.push(data.Y_ab);
       Y_bc.push(data.Y_bc);
+      Y.push(data.Y_y);
     }
 
-
     for (let i = 0; i < 20; i++) {
-      sum =
-        ponderations[polygon][0] * Y_y[i] +
-        ponderations[polygon][1] * Y_z[i] +
-        ponderations[polygon][2] * Y_mc[i] +
-        ponderations[polygon][3] * Y_ab[i] +
-        ponderations[polygon][4] * Y_bc[i];
-      sum = sum.toFixed(8);
-      result.push({ x: +(X[i] / 981).toFixed(4), y: +sum });
+      // sum =
+      //   Number((ponderations[polygon][0] * Y_y[i]).toFixed(6)) +
+      //   Number((ponderations[polygon][1] * Y_z[i]).toFixed(6)) +
+      //   Number((ponderations[polygon][2] * Y_mc[i]).toFixed(6)) +
+      //   Number((ponderations[polygon][3] * Y_ab[i]).toFixed(6)) +
+      //   Number((ponderations[polygon][4] * Y_bc[i]).toFixed(6));
+      // // console.log(sum);
+      // sum = sum.toFixed(8);
+      result.push({ x: +(X[i] / 981), y: Number(Y[i]) });
     }
 
     return result;


### PR DESCRIPTION
- change the value of the parameters sent to the interpolation helper;
- change probabilities helper to get the same graphics as the sensico page.

ATTENTION: This change turn off the use of ponderations, but the graphics are exactly equals as current sensico page. See the code and tellme what i do. Merge the change or discard. the calculations are correct but the result are different if use ponderations.

The above code is commented out for future use!